### PR TITLE
fix(discovery): handle empty XAddrs and default port

### DIFF
--- a/source/discovery.ts
+++ b/source/discovery.ts
@@ -145,7 +145,9 @@ export class DiscoverySingleton extends EventEmitter {
           let cam: Onvif | Record<string, unknown>
 
           if (options.resolve !== false) {
-            const camUris = parsedData?.probeMatches?.probeMatch?.XAddrs?.split(' ').map((uri: string) => new URL(uri))
+            const camUris = parsedData?.probeMatches?.probeMatch?.XAddrs?.split(' ')
+              .filter((uri: string) => uri.length > 0)
+              .map((uri: string) => new URL(uri))
 
             if (!camUris?.length) {
               throw new Error(`No XAddrs found for ${rinfo.address}`)
@@ -158,7 +160,7 @@ export class DiscoverySingleton extends EventEmitter {
 
             cam = new Onvif({
               hostname: camUri.hostname,
-              port: Number(camUri.port),
+              port: Number(camUri.port) || (camUri.protocol === 'https:' ? 443 : 80),
               path: camUri.pathname,
               urn: camAddr
             })


### PR DESCRIPTION
## Problem

Two issues when parsing WS-Discovery probe responses in `startProbe`:

### 1. Empty strings from `XAddrs.split(' ')`

Some cameras return `XAddrs` values with trailing spaces (e.g. `"http://192.168.1.10/onvif/device_service "`). Splitting by space produces empty strings, and `new URL("")` throws a `TypeError`.

### 2. Missing port defaults to `0`

When a camera advertises a URL without an explicit port (e.g. `http://192.168.1.10/onvif/device_service`), `URL.port` returns an empty string. `Number("")` yields `0`, which is passed to the `Onvif` constructor — resulting in connection failures.

## Fix

- Filter out empty strings after `split(' ')` before mapping to `URL` objects
- Fall back to `443` (HTTPS) or `80` (HTTP) when `URL.port` is empty

## Changes

```diff
- const camUris = parsedData?.probeMatches?.probeMatch?.XAddrs?.split(' ').map((uri: string) => new URL(uri))
+ const camUris = parsedData?.probeMatches?.probeMatch?.XAddrs?.split(' ')
+   .filter((uri: string) => uri.length > 0)
+   .map((uri: string) => new URL(uri))
```

```diff
- port: Number(camUri.port),
+ port: Number(camUri.port) || (camUri.protocol === 'https:' ? 443 : 80),
```

Both issues were encountered in production with real ONVIF cameras.